### PR TITLE
target/openrisc: On reset set CPUCFGR to features

### DIFF
--- a/target/openrisc/cpu.c
+++ b/target/openrisc/cpu.c
@@ -52,7 +52,7 @@ static void openrisc_cpu_reset(CPUState *s)
     s->exception_index = -1;
 
     cpu->env.upr = UPR_UP | UPR_DMP | UPR_IMP | UPR_PICP | UPR_TTP;
-    cpu->env.cpucfgr = CPUCFGR_OB32S | CPUCFGR_OF32S;
+    cpu->env.cpucfgr = cpu->feature;
     cpu->env.dmmucfgr = (DMMUCFGR_NTW & (0 << 2)) | (DMMUCFGR_NTS & (6 << 2));
     cpu->env.immucfgr = (IMMUCFGR_NTW & (0 << 2)) | (IMMUCFGR_NTS & (6 << 2));
 
@@ -68,7 +68,6 @@ static void openrisc_cpu_reset(CPUState *s)
 static inline void set_feature(OpenRISCCPU *cpu, int feature)
 {
     cpu->feature |= feature;
-    cpu->env.cpucfgr = cpu->feature;
 }
 
 static void openrisc_cpu_realizefn(DeviceState *dev, Error **errp)


### PR DESCRIPTION
Set the CPU Configuration Register (CPUCFGR) to the features configured
for the given CPU in the initfn function.